### PR TITLE
Add flang variant

### DIFF
--- a/.vscode/clang-aarch64-linux.cmake
+++ b/.vscode/clang-aarch64-linux.cmake
@@ -1,27 +1,4 @@
-set(TARGET_TRIPLE "aarch64-linux-gnu")
-
-set(CMAKE_C_COMPILER "/home/omair/work/tools/clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-16.04/bin/clang")
-
-set(CMAKE_CXX_COMPILER "/home/omair/work/tools/clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-16.04/bin/clang++")
-
-set(CMAKE_LIBRARY_ARCHITECTURE "${TARGET_TRIPLE}")
-
-execute_process(
-    COMMAND "gcc" -dumpversion
-    RESULT_VARIABLE HAD_ERROR
-    OUTPUT_VARIABLE GCC_V3
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-set(GCC_INC "/usr/${TARGET_TRIPLE}/include")
-
-set(CMAKE_C_FLAGS "-target ${TARGET_TRIPLE} -I/${GCC_INC} -I/${GCC_INC}/c++/${GCC_V3}/${TARGET_TRIPLE}")
-
-set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS}")
-
-execute_process(
-    COMMAND "gcc" -dumpmachine
-    RESULT_VARIABLE HAD_ERROR
-    OUTPUT_VARIABLE BUILD_ENV_TRIPLE
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-set(CMAKE_IGNORE_PATH "/usr/lib/${BUILD_ENV_TRIPLE}")
+set(LLVM_TARGET_TRIPLE "aarch64-linux-gnu")
+set(CMAKE_C_COMPILER "clang-12")
+set(CMAKE_CXX_COMPILER "clang++-12")
+set(CMAKE_LIBRARY_ARCHITECTURE "${LLVM_TARGET_TRIPLE}")

--- a/.vscode/clang-armhf-linux.cmake
+++ b/.vscode/clang-armhf-linux.cmake
@@ -1,27 +1,4 @@
-set(TARGET_TRIPLE "arm-linux-gnueabihf")
-
-set(CMAKE_C_COMPILER "/usr/bin/clang-10")
-
-set(CMAKE_CXX_COMPILER "/usr/bin/clang++-10")
-
-set(CMAKE_LIBRARY_ARCHITECTURE "${TARGET_TRIPLE}")
-
-execute_process(
-    COMMAND "gcc" -dumpversion
-    RESULT_VARIABLE HAD_ERROR
-    OUTPUT_VARIABLE GCC_V3
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-set(GCC_INC "/usr/${TARGET_TRIPLE}/include")
-
-set(CMAKE_C_FLAGS "-target ${TARGET_TRIPLE} -I/${GCC_INC} -I/${GCC_INC}/c++/${GCC_V3}/${TARGET_TRIPLE}")
-
-set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS}")
-
-execute_process(
-    COMMAND "gcc" -dumpmachine
-    RESULT_VARIABLE HAD_ERROR
-    OUTPUT_VARIABLE BUILD_ENV_TRIPLE
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-set(CMAKE_IGNORE_PATH "/usr/lib/${BUILD_ENV_TRIPLE}")
+set(LLVM_TARGET_TRIPLE "arm-linux-gnueabihf")
+set(CMAKE_C_COMPILER "clang-12")
+set(CMAKE_CXX_COMPILER "clang++-12")
+set(CMAKE_LIBRARY_ARCHITECTURE "${LLVM_TARGET_TRIPLE}")

--- a/.vscode/cmake-variants.json
+++ b/.vscode/cmake-variants.json
@@ -7,8 +7,12 @@
                 "long": "Emit debug information without performing optimizations",
                 "buildType": "Debug",
                 "settings": {
-                    "LLVM_OPTIMIZED_TABLEGEN" : "ON"
-                }               
+                    "CMAKE_INSTALL_PREFIX" : "${workspaceFolder}/install",
+                    "LLVM_OPTIMIZED_TABLEGEN" : "ON",
+                    "LLVM_USE_SPLIT_DWARF" : "ON",
+                    "LLVM_USE_LINKER" : "lld",
+                    "LLVM_PARALLEL_LINK_JOBS" : "2"
+                }
             },
             "Release": {
                 "short": "Release",
@@ -151,7 +155,6 @@
                 "short": "flang",
                 "long": "flang build configuration",
                 "settings": {
-                    "CMAKE_INSTALL_PREFIX" : "${workspaceFolder}/install",
                     "CMAKE_CXX_STANDARD" : "17",
                     "CMAKE_EXPORT_COMPILE_COMMANDS" : "ON",
                     "CMAKE_CXX_LINK_FLAGS" : "-Wl,-rpath,$LD_LIBRARY_PATH",
@@ -159,8 +162,7 @@
                     "LLVM_ENABLE_ASSERTIONS" : "ON",
                     "LLVM_TARGETS_TO_BUILD" : ["host"],
                     "LLVM_LIT_ARGS" : ["-v"],
-                    "LLVM_ENABLE_PROJECTS" : ["clang", "flang", "lld", "mlir", "openmp"],
-                    "LLVM_ENABLE_RUNTIMES" : ["compiler-rt"],
+                    "LLVM_ENABLE_PROJECTS" : ["clang", "flang", "mlir"],
                     "LLVM_PARALLEL_LINK_JOBS" : "4"
                 }
             }

--- a/.vscode/cmake-variants.json
+++ b/.vscode/cmake-variants.json
@@ -146,6 +146,23 @@
                     "LLDB_TABLEGEN" : "${workspaceFolder}/build/Release/host-linux/bin/lldb-tblgen",
                     "CLANG_TABLEGEN" : "${workspaceFolder}/build/Release/host-linux/bin/clang-tblgen"
                 }
+            },
+            "flang": {
+                "short": "flang",
+                "long": "flang build configuration",
+                "settings": {
+                    "CMAKE_INSTALL_PREFIX" : "${workspaceFolder}/install",
+                    "CMAKE_CXX_STANDARD" : "17",
+                    "CMAKE_EXPORT_COMPILE_COMMANDS" : "ON",
+                    "CMAKE_CXX_LINK_FLAGS" : "-Wl,-rpath,$LD_LIBRARY_PATH",
+                    "FLANG_ENABLE_WERROR" : "ON",
+                    "LLVM_ENABLE_ASSERTIONS" : "ON",
+                    "LLVM_TARGETS_TO_BUILD" : ["host"],
+                    "LLVM_LIT_ARGS" : ["-v"],
+                    "LLVM_ENABLE_PROJECTS" : ["clang", "flang", "lld", "mlir", "openmp"],
+                    "LLVM_ENABLE_RUNTIMES" : ["compiler-rt"],
+                    "LLVM_PARALLEL_LINK_JOBS" : "4"
+                }
             }
         }
     }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,30 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "(gdb) Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/../buildd/bin/bbc",
+            "args": ["--fdebug-dump-pre-fir", "ftest_reduced.f90"],
+            "stopAtEntry": true,
+            "cwd": "/home/leandro.lupori/work/i60229",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+        {
             "name": "(gdb attach) Debug LLDB on Linux",
             "type": "cppdbg",
             "request": "attach",


### PR DESCRIPTION
Also simplify clang-aarch64-linux.cmake and clang-armhf-linux.cmake. Using system's clang, the extra gcc include paths doesn't seem necessary (tested with clang-aarch64-linux only).

Flang settings are based on those from its GitHub page (https://github.com/llvm/llvm-project/tree/main/flang).

Tested on Ubuntu 20.04 LTS for aarch64, using clang-12 installed with apt.